### PR TITLE
Improve dark mode styles

### DIFF
--- a/src/components/Loader/Loader.css
+++ b/src/components/Loader/Loader.css
@@ -5,7 +5,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(255, 255, 255, 0.95); /* semi-transparent white (optional, for a light blur effect) */
+  /* Use the current theme background with slight transparency */
+  background-color: hsl(var(--background) / 0.9);
 }
 
 .loader-wrapper {

--- a/src/components/OurServiceCard/OurServiceCard.css
+++ b/src/components/OurServiceCard/OurServiceCard.css
@@ -13,7 +13,7 @@
 .our-card-img {
   width: 100%;
   height: 175px;
-  background: #eee;
+  background: var(--color-bg-light);
 }
 .our-card-img img {
   width: 100%;
@@ -31,7 +31,7 @@
 .our-card-title {
   font-size: 1.15rem;
   font-weight: 500;
-  color: #232323;
+  color: var(--color-text-dark);
   margin-bottom: 0.8rem;
   text-align: left;
 }
@@ -40,7 +40,7 @@
   display: flex;
   justify-content: space-between;
   font-size: 1rem;
-  color: #232323;
+  color: var(--color-text-dark);
   font-weight: 400;
   margin-bottom: 0.45rem;
 }

--- a/src/components/TestimonialCard/TestimonialCard.css
+++ b/src/components/TestimonialCard/TestimonialCard.css
@@ -36,7 +36,7 @@
 
 .testimonial-card blockquote {
   font-style: italic;
-  color: #555;
+  color: var(--color-text-muted);
   margin-bottom: 1rem;
   line-height: 1.6;
 }
@@ -50,6 +50,6 @@
 
 .testimonial-card p {
   font-size: 0.9rem;
-  color: #777;
+  color: var(--color-text-muted);
   margin: 0;
 }

--- a/src/containers/footer/Footer.css
+++ b/src/containers/footer/Footer.css
@@ -1,6 +1,6 @@
 .footer {
-  background-color: var(--color-text-dark);
-  color: white;
+  background-color: hsl(var(--background));
+  color: hsl(var(--foreground));
   padding-top: 4rem;
 }
 
@@ -30,7 +30,7 @@
 }
 
 .footer-text {
-  color: #d1d5db;
+  color: var(--color-text-muted);
   margin-bottom: 1.5rem;
 }
 
@@ -46,7 +46,7 @@
 }
 
 .footer-input::placeholder {
-  color: #9ca3af;
+  color: var(--color-text-muted);
 }
 
 .footer-subscribe-button {
@@ -66,7 +66,7 @@
   align-items: start;
   gap: 0.75rem;
   margin-bottom: 1rem;
-  color: #d1d5db;
+  color: var(--color-text-muted);
 }
 
 .footer-hours li {
@@ -97,7 +97,7 @@
   border-top: 1px solid #374151;
   text-align: center;
   padding: 1.5rem 0;
-  color: #9ca3af;
+  color: var(--color-text-muted);
   font-size: 0.875rem;
 }
 

--- a/src/containers/gift-cards/GiftCards.css
+++ b/src/containers/gift-cards/GiftCards.css
@@ -35,6 +35,15 @@
   background-color: #f8bbd0;
 }
 
+/* Dark mode overrides */
+.dark .follow-panel {
+  background-color: var(--color-card-bg);
+}
+
+.dark .promo-panel {
+  background-color: var(--color-primary);
+}
+
 .panel-content {
   text-align: center;
 }
@@ -69,6 +78,7 @@
   background-color: var(--color-primary-hover);
 }
 
+
 .promo-title {
   font-size: 2.5rem;
   font-weight: 700;
@@ -76,10 +86,16 @@
   margin-bottom: 1.5rem;
 }
 
+.dark .promo-title,
+
 .promo-text {
   font-size: 1.125rem;
   color: white;
   margin-bottom: 1.5rem;
+}
+
+.dark .promo-text {
+  color: hsl(var(--primary-foreground));
 }
 
 .promo-button {

--- a/src/pages/ServicesPage/ServicesPage.css
+++ b/src/pages/ServicesPage/ServicesPage.css
@@ -14,12 +14,12 @@
 .services-title {
   font-size: 3rem;
   font-weight: 300;
-  color: #20303c;
+  color: var(--color-text-dark);
   margin-bottom: 1.25rem;
 }
 .services-subtitle {
   font-size: 1.2rem;
-  color: #20303cbb;
+  color: var(--color-text-muted);
   max-width: 540px;
   margin: 0 auto;
 }
@@ -42,7 +42,7 @@
   gap: 2.4rem;
   justify-content: center;
   align-items: center;
-  border-bottom: 2px solid #ece2d6;
+  border-bottom: 2px solid hsl(var(--border));
   margin-bottom: 2.5rem;
   background: transparent;
   padding-left: 0.4rem;
@@ -60,7 +60,7 @@
   flex: 0 0 auto;
   background: none;
   border: none;
-  color: #1b1b1b;
+  color: var(--color-text-dark);
   font-size: 1.1rem;
   font-weight: 500;
   text-transform: uppercase;
@@ -76,7 +76,7 @@
   scroll-snap-align: start;
 }
 .services-tab.active {
-  color: #181818;
+  color: var(--color-text-dark);
   font-weight: 700;
 }
 
@@ -146,11 +146,11 @@
 .services-booking-title {
   font-size: 2rem;
   font-weight: 300;
-  color: #20303c;
+  color: var(--color-text-dark);
   margin-bottom: 1rem;
 }
 .services-booking-desc {
-  color: #20303cbb;
+  color: var(--color-text-muted);
   font-size: 1.13rem;
   margin-bottom: 2rem;
 }


### PR DESCRIPTION
## Summary
- tweak loader overlay to use theme background
- update gift card section for dark mode
- adjust testimonial card colors
- use theme variables for footer colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841004b5694833088219bd07ee2a9f9