### PR TITLE
Merge login and register into one page

### DIFF
--- a/server/models/serviceModel.js
+++ b/server/models/serviceModel.js
@@ -1,5 +1,5 @@
 import { prisma } from '../prisma/client.js';
 
 export function getAllServices() {
-  return prisma.service.findMany({ include: { category: true } });
+  return prisma.services.findMany({ include: { category: true } });
 }

--- a/server/models/transactionModel.js
+++ b/server/models/transactionModel.js
@@ -1,12 +1,12 @@
 import { prisma } from '../prisma/client.js';
 
 export function getTransactionsForUser(userId) {
-  return prisma.transaction.findMany({
+  return prisma.$transaction.findMany({
     where: { userId },
     include: { booking: true }
   });
 }
 
 export function createTransaction(data) {
-  return prisma.transaction.create({ data });
+  return prisma.$transaction.create({ data });
 }

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -19,3 +19,11 @@ export function findByIdentifier(identifier) {
 export function findById(id) {
   return prisma.user.findUnique({ where: { id } });
 }
+
+export function findByUsername(username) {
+  return prisma.user.findUnique({ where: { username } });
+}
+
+export function findByEmail(email) {
+  return prisma.user.findUnique({ where: { email } });
+}

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -1,11 +1,11 @@
 import { prisma } from '../prisma/client.js';
 
 export function createUser(data) {
-  return prisma.user.create({ data });
+  return prisma.users.create({ data });
 }
 
 export function findByIdentifier(identifier) {
-  return prisma.user.findFirst({
+  return prisma.users.findFirst({
     where: {
       OR: [
         { username: identifier },
@@ -17,13 +17,13 @@ export function findByIdentifier(identifier) {
 }
 
 export function findById(id) {
-  return prisma.user.findUnique({ where: { id } });
+  return prisma.users.findUnique({ where: { id } });
 }
 
 export function findByUsername(username) {
-  return prisma.user.findUnique({ where: { username } });
+  return prisma.users.findUnique({ where: { username } });
 }
 
 export function findByEmail(email) {
-  return prisma.user.findUnique({ where: { email } });
+  return prisma.users.findUnique({ where: { email } });
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,6 +13,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "express-validator": "^7.0.1",
         "jsonwebtoken": "^9.0.2"
       },
       "devDependencies": {
@@ -489,6 +490,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -802,6 +816,12 @@
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -1432,6 +1452,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "express-validator": "^7.0.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.3",

--- a/server/routes/authRoutes.js
+++ b/server/routes/authRoutes.js
@@ -1,22 +1,51 @@
 import express from 'express';
+import { body, validationResult } from 'express-validator';
 import { register, login } from '../services/authService.js';
+import { authMiddleware } from '../middleware/auth.js';
+import { findById } from '../models/userModel.js';
 
 const router = express.Router();
 
-router.post('/register', async (req, res) => {
-  try {
-    const user = await register(req.body);
-    res.json(user);
-  } catch {
-    res.status(400).json({ error: 'User already exists' });
+router.post(
+  '/register',
+  body('username').isLength({ min: 3 }).trim().escape(),
+  body('email').isEmail().normalizeEmail(),
+  body('password').isLength({ min: 6 }),
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const user = await register(req.body);
+      res.json(user);
+    } catch {
+      res.status(400).json({ error: 'User already exists' });
+    }
   }
-});
+);
 
-router.post('/login', async (req, res) => {
-  const { identifier, password } = req.body;
-  const result = await login(identifier, password);
-  if (!result) return res.status(401).json({ error: 'Invalid credentials' });
-  res.json(result);
+router.post(
+  '/login',
+  body('identifier').notEmpty(),
+  body('password').notEmpty(),
+  async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const { identifier, password } = req.body;
+    const result = await login(identifier, password);
+    if (!result) return res.status(401).json({ error: 'Invalid credentials' });
+    res.json(result);
+  }
+);
+
+router.get('/me', authMiddleware, async (req, res) => {
+  const user = await findById(req.userId);
+  if (!user) return res.sendStatus(404);
+  const { id, username, email, firstName, lastName, phone, language } = user;
+  res.json({ id, username, email, firstName, lastName, phone, language });
 });
 
 export default router;

--- a/server/routes/authRoutes.js
+++ b/server/routes/authRoutes.js
@@ -19,8 +19,8 @@ router.post(
     try {
       const user = await register(req.body);
       res.json(user);
-    } catch {
-      res.status(400).json({ error: 'User already exists' });
+    } catch (error) {
+      res.status(400).json({ error: error.message });
     }
   }
 );

--- a/server/services/authService.js
+++ b/server/services/authService.js
@@ -1,10 +1,14 @@
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
-import { createUser, findByIdentifier } from '../models/userModel.js';
+import { createUser, findByIdentifier, findByUsername, findByEmail } from '../models/userModel.js';
 
 const SECRET = process.env.JWT_SECRET || 'secret';
 
 export async function register(data) {
+  const existingUser = await findByUsername(data.username) || await findByEmail(data.email);
+  if (existingUser) {
+    throw new Error('User already exists');
+  }
   const hashed = await bcrypt.hash(data.password, 10);
   const user = await createUser({ ...data, password: hashed });
   return { id: user.id, username: user.username, email: user.email };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,8 +16,7 @@ const ServicesPage = lazy(() => import('./pages/ServicesPage/ServicesPage'));
 const TeamPage = lazy(() => import('./pages/TeamPage/TeamPage'));
 const ContactUsPage = lazy(() => import('./pages/ContactUsPage/ContactUsPage'));
 const GiftCardPage = lazy(() => import('./pages/GiftCardPage/GiftCardPage'));
-const LoginPage = lazy(() => import('./pages/Auth/LoginPage/LoginPage'));
-const RegisterPage = lazy(() => import('./pages/Auth/RegisterPage/RegisterPage'));
+const AuthPage = lazy(() => import('./pages/Auth/AuthPage'));
 
 const pageTransition = {
   initial: { opacity: 0, y: 30 },
@@ -106,15 +105,7 @@ function AnimatedRoutes() {
           path="/login"
           element={
             <motion.div {...pageTransition}>
-              <LoginPage />
-            </motion.div>
-          }
-        />
-        <Route
-          path="/register"
-          element={
-            <motion.div {...pageTransition}>
-              <RegisterPage />
+              <AuthPage />
             </motion.div>
           }
         />

--- a/src/__tests__/pages/pages.test.tsx
+++ b/src/__tests__/pages/pages.test.tsx
@@ -6,8 +6,7 @@ import ServicesPage from '@/pages/ServicesPage/ServicesPage'
 import TeamPage from '@/pages/TeamPage/TeamPage'
 import ContactUsPage from '@/pages/ContactUsPage/ContactUsPage'
 import GiftCardPage from '@/pages/GiftCardPage/GiftCardPage'
-import LoginPage from '@/pages/Auth/LoginPage/LoginPage'
-import RegisterPage from '@/pages/Auth/RegisterPage/RegisterPage'
+import AuthPage from '@/pages/Auth/AuthPage'
 
 describe('Page renders', () => {
   it('BookingPage', () => {
@@ -55,25 +54,14 @@ describe('Page renders', () => {
     expect(screen.getByRole('heading', { name: /gift card/i })).toBeInTheDocument()
   })
 
-  it('LoginPage', () => {
+  it('AuthPage', () => {
     render(
       <AuthProvider>
         <BrowserRouter>
-          <LoginPage />
+          <AuthPage />
         </BrowserRouter>
       </AuthProvider>
     )
     expect(screen.getByRole('heading', { name: /login/i })).toBeInTheDocument()
-  })
-
-  it('RegisterPage', () => {
-    render(
-      <AuthProvider>
-        <BrowserRouter>
-          <RegisterPage />
-        </BrowserRouter>
-      </AuthProvider>
-    )
-    expect(screen.getByRole('heading', { name: /register/i })).toBeInTheDocument()
   })
 })

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { Menu, X, ChevronDown, LogIn, UserPlus, LogOut, Sun, Moon } from "lucide-react";
+import { Menu, X, ChevronDown, LogIn, LogOut, Sun, Moon } from "lucide-react";
 import { Button } from "../ui/button";
 import { useAuth } from "@/contexts/AuthContext";
 import { cn } from "@/lib/utils";
@@ -74,14 +74,9 @@ const Header = () => {
               <LogOut size={18} className="icon-gap" /> Logout
             </button>
           ) : (
-            <>
-              <Link to="/login" className="nav-link">
-                <LogIn size={18} className="icon-gap" /> Login
-              </Link>
-              <Link to="/register" className="nav-link">
-                <UserPlus size={18} className="icon-gap" /> Register
-              </Link>
-            </>
+            <Link to="/login" className="nav-link">
+              <LogIn size={18} className="icon-gap" /> Login
+            </Link>
           )}
           <Button
             variant="ghost"
@@ -143,14 +138,9 @@ const Header = () => {
                 Logout
               </button>
             ) : (
-              <>
-                <Link to="/login" className="mobile-nav-link" onClick={() => setIsMenuOpen(false)}>
-                  Login
-                </Link>
-                <Link to="/register" className="mobile-nav-link" onClick={() => setIsMenuOpen(false)}>
-                  Register
-                </Link>
-              </>
+              <Link to="/login" className="mobile-nav-link" onClick={() => setIsMenuOpen(false)}>
+                Login
+              </Link>
             )}
             <div className="mobile-book-button">
               <Link to="/booking"><Button className="book-button">{headerContent.bookNowButton}</Button></Link>

--- a/src/pages/Auth/AuthPage.tsx
+++ b/src/pages/Auth/AuthPage.tsx
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+import LoginPage from './LoginPage/LoginPage';
+import RegisterPage from './RegisterPage/RegisterPage';
+
+const AuthPage = () => {
+  const [mode, setMode] = useState<'login' | 'register'>('login');
+  return mode === 'login' ? (
+    <LoginPage switchToRegister={() => setMode('register')} />
+  ) : (
+    <RegisterPage switchToLogin={() => setMode('login')} />
+  );
+};
+
+export default AuthPage;

--- a/src/pages/Auth/LoginPage/LoginPage.css
+++ b/src/pages/Auth/LoginPage/LoginPage.css
@@ -40,3 +40,20 @@
   color: #e11d48;
   text-align: center;
 }
+
+.switch-text {
+  text-align: center;
+  color: var(--color-text-muted);
+  margin-top: 0.75rem;
+  font-size: 0.875rem;
+}
+
+.switch-link {
+  color: var(--color-primary);
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.switch-link:hover {
+  text-decoration: underline;
+}

--- a/src/pages/Auth/LoginPage/LoginPage.tsx
+++ b/src/pages/Auth/LoginPage/LoginPage.tsx
@@ -1,11 +1,16 @@
 import { useState } from 'react';
+import { LogIn } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/AuthContext';
 import './LoginPage.css';
 
-const LoginPage = () => {
+interface Props {
+  switchToRegister?: () => void;
+}
+
+const LoginPage = ({ switchToRegister }: Props) => {
   const { login } = useAuth();
   const navigate = useNavigate();
   const [identifier, setIdentifier] = useState('');
@@ -25,7 +30,9 @@ const LoginPage = () => {
   return (
     <div className="login-bg">
       <form className="login-form" onSubmit={handleSubmit}>
-        <h1 className="login-title">Login</h1>
+        <h1 className="login-title flex items-center justify-center gap-2">
+          <LogIn size={24} /> Login
+        </h1>
         <Input
           placeholder="Email, Username or Phone"
           value={identifier}
@@ -39,6 +46,14 @@ const LoginPage = () => {
         />
         {error && <p className="login-error">{error}</p>}
         <Button type="submit" className="login-button">Sign In</Button>
+        {switchToRegister && (
+          <p className="switch-text">
+            Not signed up yet?{' '}
+            <span className="switch-link" onClick={switchToRegister}>
+              Register
+            </span>
+          </p>
+        )}
       </form>
     </div>
   );

--- a/src/pages/Auth/LoginPage/LoginPage.tsx
+++ b/src/pages/Auth/LoginPage/LoginPage.tsx
@@ -19,11 +19,11 @@ const LoginPage = ({ switchToRegister }: Props) => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const success = await login(identifier, password);
-    if (success) {
+    const result = await login(identifier, password);
+    if (result.success) {
       navigate('/');
     } else {
-      setError('Invalid credentials');
+      setError(result.message || 'Login failed');
     }
   };
 

--- a/src/pages/Auth/LoginPage/LoginPage.tsx
+++ b/src/pages/Auth/LoginPage/LoginPage.tsx
@@ -17,9 +17,9 @@ const LoginPage = ({ switchToRegister }: Props) => {
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const success = login(identifier, password);
+    const success = await login(identifier, password);
     if (success) {
       navigate('/');
     } else {

--- a/src/pages/Auth/RegisterPage/RegisterPage.tsx
+++ b/src/pages/Auth/RegisterPage/RegisterPage.tsx
@@ -1,11 +1,16 @@
 import { useState } from 'react';
+import { UserPlus } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/AuthContext';
 import './RegisterPage.css';
 
-const RegisterPage = () => {
+interface Props {
+  switchToLogin?: () => void;
+}
+
+const RegisterPage = ({ switchToLogin }: Props) => {
   const { register } = useAuth();
   const navigate = useNavigate();
   const [username, setUsername] = useState('')
@@ -39,7 +44,9 @@ const RegisterPage = () => {
   return (
     <div className="login-bg">
       <form className="login-form" onSubmit={handleSubmit}>
-        <h1 className="login-title">Register</h1>
+        <h1 className="login-title flex items-center justify-center gap-2">
+          <UserPlus size={24} /> Register
+        </h1>
         <Input
           placeholder="Username"
           value={username}
@@ -91,6 +98,14 @@ const RegisterPage = () => {
         />
         {error && <p className="login-error">{error}</p>}
         <Button type="submit" className="login-button">Sign Up</Button>
+        {switchToLogin && (
+          <p className="switch-text">
+            Already have an account?{' '}
+            <span className="switch-link" onClick={switchToLogin}>
+              Login
+            </span>
+          </p>
+        )}
       </form>
     </div>
   );

--- a/src/pages/Auth/RegisterPage/RegisterPage.tsx
+++ b/src/pages/Auth/RegisterPage/RegisterPage.tsx
@@ -23,13 +23,13 @@ const RegisterPage = ({ switchToLogin }: Props) => {
   const [confirm, setConfirm] = useState('')
   const [error, setError] = useState('');
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (password !== confirm) {
       setError('Passwords do not match');
       return;
     }
-    register({
+    const success = await register({
       username,
       email,
       firstName,
@@ -37,8 +37,8 @@ const RegisterPage = ({ switchToLogin }: Props) => {
       phone,
       language,
       password,
-    })
-    navigate('/');
+    });
+    if (success) navigate('/');
   };
 
   return (

--- a/src/pages/Auth/RegisterPage/RegisterPage.tsx
+++ b/src/pages/Auth/RegisterPage/RegisterPage.tsx
@@ -29,7 +29,7 @@ const RegisterPage = ({ switchToLogin }: Props) => {
       setError('Passwords do not match');
       return;
     }
-    const success = await register({
+    const result = await register({
       username,
       email,
       firstName,
@@ -38,7 +38,11 @@ const RegisterPage = ({ switchToLogin }: Props) => {
       language,
       password,
     });
-    if (success) navigate('/');
+    if (result.success) {
+      navigate('/');
+    } else {
+      setError(result.message || 'Registration failed');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- combine login and register components via new `AuthPage`
- add switch links between forms
- update headers with icons
- simplify header nav to single login link
- update tests for unified page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68411441a3c88330b73a5c8ae2cc38e6