### PR TITLE
Add booking confirmation page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { lazy, Suspense, useEffect } from 'react';
 import Loader from './components/Loader/Loader';
 
 const BookingPage = lazy(() => import('./pages/BookingPage/BookingPage'));
+const BookingConfirmationPage = lazy(() => import('./pages/BookingConfirmationPage/BookingConfirmationPage'));
 const ServicesPage = lazy(() => import('./pages/ServicesPage/ServicesPage'));
 const TeamPage = lazy(() => import('./pages/TeamPage/TeamPage'));
 const ContactUsPage = lazy(() => import('./pages/ContactUsPage/ContactUsPage'));
@@ -58,6 +59,14 @@ function AnimatedRoutes() {
           element={
             <motion.div {...pageTransition}>
               <BookingPage />
+            </motion.div>
+          }
+        />
+        <Route
+          path="/booking/confirmation"
+          element={
+            <motion.div {...pageTransition}>
+              <BookingConfirmationPage />
             </motion.div>
           }
         />

--- a/src/components/ReviewModal/ReviewModal.tsx
+++ b/src/components/ReviewModal/ReviewModal.tsx
@@ -7,7 +7,7 @@ interface ReviewModalProps {
   onClose: () => void;
   onConfirm: (e: React.FormEvent) => void;
   formData: {
-    category: CategoryServiceItem;
+    category?: CategoryServiceItem | null;
     service: string;
     designer: string;
     start: Date | null;
@@ -23,7 +23,7 @@ const ReviewModal: React.FC<ReviewModalProps> = ({ open, onClose, onConfirm, for
       <div className="modal-content">
         <h3>Review & Confirm</h3>
         <ul>
-          <li><strong>Category:</strong> {formData.category.title}</li>
+          <li><strong>Category:</strong> {formData.category?.title || formData.category?.name || 'N/A'}</li>
           <li><strong>Service:</strong> {formData.service}</li>
           <li><strong>Artist:</strong> {formData.designer}</li>
           <li>

--- a/src/containers/preparation-tips/PreparationTips.css
+++ b/src/containers/preparation-tips/PreparationTips.css
@@ -1,0 +1,15 @@
+.prep-tips {
+  background: #f8f8f8;
+  padding: 1rem;
+  border-radius: 4px;
+}
+.prep-tips-title {
+  margin-bottom: 0.5rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+.prep-tips-list {
+  list-style-type: disc;
+  padding-left: 1.5rem;
+  text-align: left;
+}

--- a/src/containers/preparation-tips/PreparationTips.tsx
+++ b/src/containers/preparation-tips/PreparationTips.tsx
@@ -1,0 +1,21 @@
+import './PreparationTips.css';
+
+const tips = [
+  'Arrive 10 minutes early to unwind and check in.',
+  'Remove any existing nail polish before your appointment.',
+  "Avoid heavy hand lotions on the day for better polish adhesion.",
+  "If you're feeling unwell, please reschedule for everyone's safety."
+];
+
+const PreparationTips = () => (
+  <section className="prep-tips">
+    <h3 className="prep-tips-title">Preparation Tips</h3>
+    <ul className="prep-tips-list">
+      {tips.map((tip, idx) => (
+        <li key={idx}>{tip}</li>
+      ))}
+    </ul>
+  </section>
+);
+
+export default PreparationTips;

--- a/src/pages/BookingConfirmationPage/BookingConfirmationPage.css
+++ b/src/pages/BookingConfirmationPage/BookingConfirmationPage.css
@@ -1,0 +1,11 @@
+.booking-confirmation-page {
+  padding: 2rem;
+  text-align: center;
+}
+.booking-confirmation-header {
+  margin-bottom: 1.5rem;
+}
+.booking-confirmation-main {
+  max-width: 600px;
+  margin: 0 auto;
+}

--- a/src/pages/BookingConfirmationPage/BookingConfirmationPage.tsx
+++ b/src/pages/BookingConfirmationPage/BookingConfirmationPage.tsx
@@ -1,0 +1,16 @@
+import PreparationTips from '@/containers/preparation-tips/PreparationTips';
+import './BookingConfirmationPage.css';
+
+const BookingConfirmationPage = () => (
+  <div className="booking-confirmation-page">
+    <header className="booking-confirmation-header">
+      <h2>Your Booking is Confirmed!</h2>
+      <p>Thank you for choosing Dreamy Nail & Beauty. We look forward to seeing you.</p>
+    </header>
+    <main className="booking-confirmation-main">
+      <PreparationTips />
+    </main>
+  </div>
+);
+
+export default BookingConfirmationPage;

--- a/src/pages/BookingPage/BookingPage.tsx
+++ b/src/pages/BookingPage/BookingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import './BookingPage.css';
 import ServiceCategorySelector from '@/components/ServiceCategorySelector/ServiceCategorySelector';
 import ServiceSelector from '@/components/ServiceSelector/ServiceSelector';
@@ -26,6 +26,7 @@ const steps = [
 
 const BookingPage = () => {
   const location = useLocation();
+  const navigate = useNavigate();
   const navState = location.state || {};
 
   const [categories, setCategories] = useState<CategoryServiceItem[]>([]);
@@ -241,6 +242,7 @@ useEffect(() => {
           setShowReview(false);
           setStep(0);
           setFormData({ category: null, service: '', designer: '', start: null, end: null });
+          navigate('/booking/confirmation');
         } else {
           const data = await res.json().catch(() => ({}));
           let message = data.error || 'Failed to save booking.';


### PR DESCRIPTION
## Summary
- show category name in review modal if available
- navigate to booking confirmation page after successful booking
- add booking confirmation page route
- provide basic preparation tips

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844797639588330b9339e5c5cba50a6